### PR TITLE
Fixing spurious license comment in recently added files

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,5 +1,10 @@
-// Copyright PA Knowledge 2023
-
+/*
+ * Copyright (c) 2023
+ *
+ * This software is licensed under the MIT License.
+ * SPDX-License-Identifier: MIT
+ *
+ */
 #include <mpsc/channel.hpp>
 
 #include <cassert>

--- a/include/mpsc/channel.hpp
+++ b/include/mpsc/channel.hpp
@@ -1,44 +1,54 @@
 ﻿/*
-mpsc_channel.hpp
-A simple C++ implementation of the 'channel' in rust language (std::mpsc).
+ * Copyright (c) 2019 liuchibing.
+ *
+ * This software is licensed under the MIT License.
+ * SPDX-License-Identifier: MIT
+ *
+ */
 
-# Usage
-Use `mpsc::make_channel<T>` to create a channel. `make_channel<T>` will return a tuple of (Sender<T>, Receiver<T>).
-
-For example:
-```c++
-// Create.
-auto [ sender, receiver ] = mpsc::make_channel<int>();
-
-// Send.
-sender.send(3);
-
-// Receive (both returns a std::optional<T>.)
-receiver.receive(); // Blocking when there is nothing present in the channel.
-receiver.try_receive(); // Not blocking. Return immediately.
-
-// close() and closed()
-sender.close();
-bool result = sender.closed();
-assert(result == receiver.closed());
-
-// You can use range-based for loop to receive from the channel.
-for (int v: receiver) {
-        // do something with v
-        // The loop will stop immedately after the sender called close().
-        // Only sender can call close().
-}
-```
-
-Note: `mpsc` stands for Multi-Producer Single-Consumer. So `Sender` can be either copied and moved, but `Receiver` can only be
-moved.
-
-Feel free to explore the `tests.cpp`. The tests are also examples of the usage.
-
-Read the source if you need more information. Sorry for the lack of comments. ～(￣▽￣～)~
-
-Copyright (c) 2019 liuchibing.
-*/
+/**
+ * @file channel.hpp
+ *
+ * @brief A simple C++ implementation of the 'channel' in Rust language (std::mpsc).
+ *
+ * # Usage
+ *
+ * Use `mpsc::make_channel<T>` to create a channel. `make_channel<T>` will return a tuple of (Sender<T>, Receiver<T>).
+ *
+ * For example:
+ *
+ * @code{.cpp}
+ * // Create.
+ * auto [sender, receiver] = mpsc::make_channel<int>();
+ *
+ * // Send.
+ * sender.send(3);
+ *
+ * // Receive (both returns a std::optional<T>.)
+ * receiver.receive(); // Blocking when there is nothing present in the channel.
+ * receiver.try_receive(); // Not blocking. Return immediately.
+ *
+ * // close() and closed()
+ * sender.close();
+ * bool result = sender.closed();
+ * assert(result == receiver.closed());
+ *
+ * // You can use range-based for loop to receive from the channel.
+ * for (int v: receiver) {
+ *   // do something with v
+ *
+ *   // The loop will stop immedately after the sender called close().
+ *   // Only sender can call close().
+ * }
+ * @endcode
+ *
+ * @note mpsc stands for Multi-Producer Single-Consumer. So Sender can be either
+ * copied and moved, but Receiver can only be moved.
+ *
+ * Feel free to explore the tests.cpp. The tests are also examples of the usage.
+ *
+ * Read the source if you need more information. Sorry for the lack of comments. ~( ̄▽ ̄)~
+ */
 
 #include <condition_variable>
 #include <exception>

--- a/test/channel_tests.cpp
+++ b/test/channel_tests.cpp
@@ -1,5 +1,10 @@
-// Copyright PA Knowledge 2023
-
+/*
+ * Copyright (c) 2023
+ *
+ * This software is licensed under the MIT License.
+ * SPDX-License-Identifier: MIT
+ *
+ */
 #include <mpsc/channel.hpp>
 
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
Accidentally created irrelevant copyright notice in some newly added files. This PR fixes that and corrects to MIT license.

Also re-formatted doc-comment in channel.hpp so that it uses Doxygen format. This will allow any readers that support that to parse and present the comment properly.