### PR TITLE
Close a channel when all its senders have gone out of scope. Resolves #5

### DIFF
--- a/include/mpsc/channel.hpp
+++ b/include/mpsc/channel.hpp
@@ -136,7 +136,7 @@ class Sender {
 
   void close() {
     validate();
-    channel->close();
+    channel_closer.reset();
   }
 
   [[nodiscard]] bool closed() const {

--- a/include/mpsc/channel.hpp
+++ b/include/mpsc/channel.hpp
@@ -117,7 +117,9 @@ class Sender {
     public:
         explicit ChannelCloser(detail::Channel<T>& channel) : channel{channel} {}
         ~ChannelCloser(){
-            channel.close();
+            if ( not channel.closed()) {
+                channel.close();
+            }
         }
     };
 

--- a/test/channel_tests.cpp
+++ b/test/channel_tests.cpp
@@ -79,5 +79,21 @@ TEST_CASE("Channel tests") {
       REQUIRE(std::vector{ 12 } == recvd);
       REQUIRE(std::future_status::ready == async_recv.wait_for(1s));
     }
+
+    SECTION("Channel is closed when its last sender goes out of scope") {
+        auto [tx_1, rx_1] = mpsc::make_channel<double>();
+        {
+            auto _1 = tx_1;  // This copy keeps the channel alive while it's in scope.
+            {
+                auto _2 = _1;
+                {
+                    auto tx_to_kill = std::move(tx_1);
+                }
+                REQUIRE_FALSE(rx_1.closed());
+            }
+            REQUIRE_FALSE(rx_1.closed());
+        }
+        REQUIRE(rx_1.closed());
+    }
   }
 }

--- a/test/channel_tests.cpp
+++ b/test/channel_tests.cpp
@@ -19,84 +19,84 @@
 using namespace std::chrono_literals;
 
 TEST_CASE("Channel tests") {
-  auto rng = std::mt19937_64{7654236};  // Arbitrary seed.
+    auto rng = std::mt19937_64{7654236};  // Arbitrary seed.
 
-  SECTION("Trivially constructable values") {
-    auto [tx, rx] = mpsc::make_channel<int>();
+    SECTION("Trivially constructable values") {
+        auto [tx, rx] = mpsc::make_channel<int>();
 
-    SECTION("A single value can be sent and received") {
-      auto sent_value = std::uniform_int_distribution<int>{}(rng);
-      tx.send(sent_value);
-      const auto rcvd = rx.receive();
+        SECTION("A single value can be sent and received") {
+            auto sent_value = std::uniform_int_distribution<int>{}(rng);
+            tx.send(sent_value);
+            const auto rcvd = rx.receive();
 
-      REQUIRE(rcvd.has_value());
-      REQUIRE(sent_value == rcvd.value());
-    }
+            REQUIRE(rcvd.has_value());
+            REQUIRE(sent_value == rcvd.value());
+        }
 
-    SECTION("Multiple values can be sequentially sent and received") {
-      for (auto i = 0; i < 10; ++i) {
-        auto sent_value = std::uniform_int_distribution<int>{}(rng);
-        tx.send(sent_value);
-        const auto rcvd = rx.receive();
+        SECTION("Multiple values can be sequentially sent and received") {
+            for (auto i = 0; i < 10; ++i) {
+                auto sent_value = std::uniform_int_distribution<int>{}(rng);
+                tx.send(sent_value);
+                const auto rcvd = rx.receive();
 
-        REQUIRE(rcvd.has_value());
-        REQUIRE(sent_value == rcvd.value());
-      }
-    }
+                REQUIRE(rcvd.has_value());
+                REQUIRE(sent_value == rcvd.value());
+            }
+        }
 
-    SECTION("Multiple values can be sent and then received later"){
-      for (int i : std::ranges::iota_view{0, 10}) {
-        tx.send(i);
-      }
+        SECTION("Multiple values can be sent and then received later") {
+            for (int i: std::ranges::iota_view{0, 10}) {
+                tx.send(i);
+            }
 
-      auto vals = std::vector<int>{};
-      std::copy_n(rx.begin(), 10, std::back_inserter(vals));
+            auto vals = std::vector<int>{};
+            std::copy_n(rx.begin(), 10, std::back_inserter(vals));
 
-      REQUIRE(std::vector{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} == vals);
-    }
+            REQUIRE(std::vector{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} == vals);
+        }
 
-    SECTION("Closing sender ends receiver iterator wait") {
-      auto receiving_now = std::condition_variable{};
-      auto mtx = std::mutex{};
-      auto lock = std::unique_lock<std::mutex>{mtx};
+        SECTION("Closing sender ends receiver iterator wait") {
+            auto receiving_now = std::condition_variable{};
+            auto mtx = std::mutex{};
+            auto lock = std::unique_lock<std::mutex>{mtx};
 
-      auto recvd = std::vector<int>{};
-      tx.send(12);
+            auto recvd = std::vector<int>{};
+            tx.send(12);
 
-      auto async_recv = std::async([&](){
-        receiving_now.notify_all();
-        std::copy(rx.begin(), rx.end(), std::back_inserter(recvd));
-      });
+            auto async_recv = std::async([&]() {
+                receiving_now.notify_all();
+                std::copy(rx.begin(), rx.end(), std::back_inserter(recvd));
+            });
 
-      receiving_now.wait(lock);
+            receiving_now.wait(lock);
 
-      // Wait for a short time to ensure that the available items are processed
-      std::this_thread::sleep_for(10ms);
+            // Wait for a short time to ensure that the available items are processed
+            std::this_thread::sleep_for(10ms);
 
-      // Closing the transmitter should terminate the receiver.
-      tx.close();
+            // Closing the transmitter should terminate the receiver.
+            tx.close();
 
-      REQUIRE(std::vector{ 12 } == recvd);
-      REQUIRE(std::future_status::ready == async_recv.wait_for(1s));
-    }
+            REQUIRE(std::vector{12} == recvd);
+            REQUIRE(std::future_status::ready == async_recv.wait_for(1s));
+        }
 
-    SECTION("Channel is closed when its last sender goes out of scope") {
-        auto [tx_1, rx_1] = mpsc::make_channel<double>();
-        {
-            auto _1 = tx_1;  // This copy keeps the channel alive while it's in scope.
+        SECTION("Channel is closed when its last sender goes out of scope") {
+            auto [tx_1, rx_1] = mpsc::make_channel<double>();
             {
-                auto _2 = _1;
+                auto _1 = tx_1;  // This copy keeps the channel alive while it's in scope.
                 {
-                    auto tx_to_kill = std::move(tx_1);
+                    auto _2 = _1;
+                    {
+                        auto tx_to_kill = std::move(tx_1);
+                    }
+                    REQUIRE_FALSE(rx_1.closed());
                 }
                 REQUIRE_FALSE(rx_1.closed());
             }
-            REQUIRE_FALSE(rx_1.closed());
+            REQUIRE(rx_1.closed());
         }
-        REQUIRE(rx_1.closed());
-    }
 
-    SECTION("Closing a sender manually doesn't mess up scope-based channel closing") {
+        SECTION("Closing a sender manually doesn't mess up scope-based channel closing") {
             auto [tx_1, rx_1] = mpsc::make_channel<double>();
             {
                 auto tx_2 = tx_1;  // This copy keeps the channel alive while it's in scope.
@@ -112,6 +112,13 @@ TEST_CASE("Channel tests") {
                 REQUIRE_FALSE(rx_1.closed());
             }
             REQUIRE(rx_1.closed());
+        }
+
+        SECTION("Channel closer respects the closed state of the channel when trying to close it") {
+            auto [tx_1, rx_1] = mpsc::make_channel<double>();
+            tx_1.close();
+
+            REQUIRE(rx_1.closed());
+        }
     }
-  }
 }

--- a/test/channel_tests.cpp
+++ b/test/channel_tests.cpp
@@ -95,5 +95,23 @@ TEST_CASE("Channel tests") {
         }
         REQUIRE(rx_1.closed());
     }
+
+    SECTION("Closing a sender manually doesn't mess up scope-based channel closing") {
+            auto [tx_1, rx_1] = mpsc::make_channel<double>();
+            {
+                auto tx_2 = tx_1;  // This copy keeps the channel alive while it's in scope.
+                {
+                    auto tx_3 = tx_2;
+                    {
+                        auto tx_to_kill = std::move(tx_1);
+                    }
+                    REQUIRE_FALSE(rx_1.closed());
+
+                    tx_3.close();
+                }
+                REQUIRE_FALSE(rx_1.closed());
+            }
+            REQUIRE(rx_1.closed());
+    }
   }
 }


### PR DESCRIPTION
This PR introduces a `ChannelCloser` that is owned by the sender as a shared pointer. Copying the sender copies the shared_ptr.  When the last sender is destroyed it destroys the `ChannelCloser`, which closes the channel in its destructor.